### PR TITLE
Updating example applications paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ We have three categories of examples.
 * [code-examples](code-examples/) Contains two examples showing Lightning/PopTorch integration.
     * [shakespeare-rnn](code-examples/shakespeare-rnn) A port of an existing PyTorch RNN to run on IPU through Lightning.
     * [fashion-mnist](code-examples/fashion-mnist) Runs two different ResNets, one a modified torchvision backbone the other written from scratch
-* [applications](applications) A port of the [Convolutional Neural Network training application](https://github.com/graphcore/examples/tree/master/applications/pytorch/cnns/train) from Graphcore's [examples](https://github.com/graphcore/examples) repo using Lightning. This can be used to run, and benchmark, many CNN examples.
+* [applications](applications) A port of the [Convolutional Neural Network training application](https://github.com/graphcore/examples/tree/master/vision/cnns/pytorch/train) from Graphcore's [examples](https://github.com/graphcore/examples) repo using Lightning. This can be used to run, and benchmark, many CNN examples.

--- a/applications/README.md
+++ b/applications/README.md
@@ -1,6 +1,6 @@
 # PyTorch CNN application
 
-This directory contains a PyTorch Lightning port of the [PyTorch CNNs training application from the Graphcore GitHub examples repository](https://github.com/graphcore/examples/tree/master/applications/pytorch/cnns/train).
+This directory contains a PyTorch Lightning port of the [PyTorch CNNs training application from the Graphcore GitHub examples repository](https://github.com/graphcore/examples/tree/master/vision/cnns/pytorch/train).
 
 It can be used to verify that the same performance is obtained with PyTorch Lightning as we do when running directly in PopTorch.
 
@@ -27,10 +27,10 @@ To run the CNN application using PyTorch Lightning:
 ```
 git submodule init
 git submodule update
-pip3 install -r ./examples/applications/pytorch/cnns/requirements.txt
+pip3 install -r ./examples/vision/cnns/pytorch/requirements.txt
 ```
 
-See the README.md in examples/applications/pytorch/cnns for full documentation, the
+See the README.md in examples/vision/cnns/pytorch/ for full documentation, the
 following run command and options are repeated here for ease of use.
 
 ```

--- a/applications/train_lightning.py
+++ b/applications/train_lightning.py
@@ -16,12 +16,12 @@ import sys
 import os
 
 
-if not os.path.exists('examples/applications/pytorch/cnns/train'):
+if not os.path.exists('examples/vision/cnns/pytorch/train'):
     print("Could not find the CNN examples directory, have you run git submodule init/update?")
     exit()
 
-sys.path.append('examples/applications/pytorch/cnns/')
-sys.path.append('examples/applications/pytorch/cnns/train')
+sys.path.append('examples/vision/cnns/pytorch/')
+sys.path.append('examples/vision/cnns/pytorch/train')
 
 from train_utils import parse_arguments
 from validate import create_validation_opts

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -16,7 +16,7 @@ class ApplicationsTest(SubProcessChecker):
         self.run_command("git submodule init", self.current_path, [])
         self.run_command("git submodule update", self.current_path, [])
         self.run_command(
-            "pip3 install -r ./examples/applications/pytorch/cnns/requirements.txt", self.current_path, [])
+            "pip3 install -r ./examples/vision/cnns/pytorch/requirements.txt", self.current_path, [])
 
     @pytest.mark.category2
     @pytest.mark.ipus(16)


### PR DESCRIPTION
Updating paths that point to the pytorch CNNs files in examples, as of release-2.6